### PR TITLE
Use ValidatorBuilder to load constraint message translations

### DIFF
--- a/src/setup.php
+++ b/src/setup.php
@@ -1,6 +1,7 @@
 <?php
 
 use Symfony\Component\Validator\Validation;
+use Symfony\Component\Validator\ValidatorBuilder;
 use Symfony\Bridge\Twig\Form\TwigRendererEngine;
 use Symfony\Component\Form\Forms;
 use Symfony\Component\Form\Extension\Validator\ValidatorExtension;
@@ -23,14 +24,18 @@ define('VIEWS_DIR', realpath(__DIR__ . '/../views'));
 // Set up the CSRF Token Manager
 $csrfTokenManager = new CsrfTokenManager();
 
-// Set up the Validator component
-$validator = Validation::createValidator();
-
 // Set up the Translation component
 $translator = new Translator('en');
 $translator->addLoader('xlf', new XliffFileLoader());
 $translator->addResource('xlf', VENDOR_FORM_DIR . '/Resources/translations/validators.en.xlf', 'en', 'validators');
 $translator->addResource('xlf', VENDOR_VALIDATOR_DIR . '/Resources/translations/validators.en.xlf', 'en', 'validators');
+
+// Set up the Validator component
+$builder = new ValidatorBuilder();
+$validator = $builder
+     ->setTranslator($translator)
+     ->setTranslationDomain('validators')
+     ->getValidator();
 
 $twig = new Twig_Environment(new Twig_Loader_Filesystem(array(
     VIEWS_DIR,


### PR DESCRIPTION
Per issue #13, this fixes the use of translation xlf documents.